### PR TITLE
S3-03 — PNP Mapper (clean split)

### DIFF
--- a/src/screens/PNPMapper.tsx
+++ b/src/screens/PNPMapper.tsx
@@ -1,0 +1,270 @@
+﻿// src/screens/PNPMapper.tsx
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  ScrollView,
+  Switch,
+  Pressable,
+  Linking,
+  ActivityIndicator,
+  StyleSheet,
+} from "react-native";
+import { loadPnpGuides, matchStreams, PnpProfileInput, RankedStream } from "../services/pnp";
+
+type Source = "remote" | "cache" | "local";
+
+export default function PNPMapper() {
+  // loader state
+  const [loading, setLoading] = useState(true);
+  const [source, setSource] = useState<Source>("local");
+  const [fetchedAt, setFetchedAt] = useState<string | null>(null);
+  const [status, setStatus] = useState<200 | 304 | undefined>(undefined);
+  const [error, setError] = useState<string | null>(null);
+  const [guides, setGuides] = useState<any | null>(null);
+
+  // profile toggles
+  const [profile, setProfile] = useState<PnpProfileInput>({
+    hasExpressEntryProfile: false,
+    hasJobOffer: false,
+    isTech: false,
+    isHealth: false,
+    isTrades: false,
+    isFrancophone: false,
+    isIntlStudentOrGrad: false,
+    hasProvincialTies: false,
+    isOccupationInDemand: false,
+  });
+
+  // load once
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const res = await loadPnpGuides();
+        if (!mounted) return;
+        if (res.ok && res.data) {
+          setGuides(res.data);
+          setSource(res.source);
+          setFetchedAt(res.meta?.last_checked ?? null);
+          setStatus(res.meta?.status);
+        } else {
+          setError(res.error ?? "Failed to load PNP guides.");
+        }
+      } catch (e: any) {
+        setError(e?.message || "Failed to load PNP guides.");
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const results: RankedStream[] = useMemo(() => {
+    if (!guides) return [];
+    return matchStreams(guides, profile, 20);
+  }, [guides, profile]);
+
+  const headerLabel = useMemo(() => {
+    const src = source === "remote" ? "Remote" : source === "cache" ? "Cache" : "Local";
+    const st =
+      status === 200 ? "updated" : status === 304 ? "validated" : source === "local" ? "bundled" : "";
+    const ts = fetchedAt ? new Date(fetchedAt).toLocaleString() : "";
+    return `Source: ${src}${st ? ` • ${st}` : ""}${ts ? ` • last checked ${ts}` : ""}`;
+  }, [source, status, fetchedAt]);
+
+  function ToggleRow({
+    label,
+    value,
+    onValueChange,
+    testID,
+  }: {
+    label: string;
+    value: boolean;
+    onValueChange: (v: boolean) => void;
+    testID?: string;
+  }) {
+    return (
+      <View style={styles.toggleRow}>
+        <Text style={styles.toggleLabel}>{label}</Text>
+        <Switch testID={testID} value={value} onValueChange={onValueChange} />
+      </View>
+    );
+  }
+
+  function StreamCard({ item }: { item: RankedStream }) {
+    return (
+      <View style={styles.card}>
+        <Text style={styles.cardTitle}>{item.title}</Text>
+        <Text style={styles.cardSub}>{item.province}</Text>
+
+        {item.matched?.length ? (
+          <View style={styles.tagsRow}>
+            {item.matched.map((c) => (
+              <View key={c} style={styles.tag}>
+                <Text style={styles.tagText}>{c}</Text>
+              </View>
+            ))}
+          </View>
+        ) : null}
+
+        {item.hints?.length ? (
+          <View style={{ marginTop: 6 }}>
+            {item.hints.map((h, i) => (
+              <Text key={i} style={styles.hint}>• {h}</Text>
+            ))}
+          </View>
+        ) : null}
+
+        <Pressable
+          onPress={() => Linking.openURL(item.officialUrl)}
+          style={({ pressed }) => [styles.linkBtn, pressed && { opacity: 0.8 }]}
+        >
+          <Text style={styles.linkBtnText}>Open official page</Text>
+        </Pressable>
+      </View>
+    );
+  }
+
+  if (loading) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+        <Text style={{ marginTop: 8 }}>Loading PNP streams…</Text>
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.center}>
+        <Text style={styles.errorTitle}>Couldn’t load PNP data</Text>
+        <Text style={styles.errorSub}>{error}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <Text style={styles.header}>PNP Mapper</Text>
+      <Text style={styles.meta}>{headerLabel}</Text>
+
+      <View style={styles.block}>
+        <Text style={styles.blockTitle}>Your profile</Text>
+
+        <ToggleRow
+          label="I already have an Express Entry profile"
+          value={!!profile.hasExpressEntryProfile}
+          onValueChange={(v) => setProfile((p) => ({ ...p, hasExpressEntryProfile: v }))}
+          testID="pnp-ee"
+        />
+        <ToggleRow
+          label="I have a (valid) Canadian job offer / employer"
+          value={!!profile.hasJobOffer}
+          onValueChange={(v) => setProfile((p) => ({ ...p, hasJobOffer: v }))}
+          testID="pnp-job"
+        />
+        <ToggleRow
+          label="My field is Tech / IT"
+          value={!!profile.isTech}
+          onValueChange={(v) => setProfile((p) => ({ ...p, isTech: v }))}
+          testID="pnp-tech"
+        />
+        <ToggleRow
+          label="My field is Health / Nursing"
+          value={!!profile.isHealth}
+          onValueChange={(v) => setProfile((p) => ({ ...p, isHealth: v }))}
+          testID="pnp-health"
+        />
+        <ToggleRow
+          label="I’m in Skilled Trades"
+          value={!!profile.isTrades}
+          onValueChange={(v) => setProfile((p) => ({ ...p, isTrades: v }))}
+          testID="pnp-trades"
+        />
+        <ToggleRow
+          label="I’m Francophone (French CLB ≈ 7+)"
+          value={!!profile.isFrancophone}
+          onValueChange={(v) => setProfile((p) => ({ ...p, isFrancophone: v }))}
+          testID="pnp-fr"
+        />
+        <ToggleRow
+          label="I’m an international student/graduate in Canada"
+          value={!!profile.isIntlStudentOrGrad}
+          onValueChange={(v) => setProfile((p) => ({ ...p, isIntlStudentOrGrad: v }))}
+          testID="pnp-intl"
+        />
+        <ToggleRow
+          label="I have ties to a province (family/study/work/invitation)"
+          value={!!profile.hasProvincialTies}
+          onValueChange={(v) => setProfile((p) => ({ ...p, hasProvincialTies: v }))}
+          testID="pnp-ties"
+        />
+        <ToggleRow
+          label="My occupation is currently ‘in-demand’"
+          value={!!profile.isOccupationInDemand}
+          onValueChange={(v) => setProfile((p) => ({ ...p, isOccupationInDemand: v }))}
+          testID="pnp-demand"
+        />
+      </View>
+
+      <View style={styles.block}>
+        <Text style={styles.blockTitle}>Suggested streams</Text>
+        {results.length === 0 ? (
+          <Text style={{ color: "#666", marginTop: 6 }}>
+            No matches yet. Turn on one or more profile options above, or leave all off to browse all streams.
+          </Text>
+        ) : null}
+
+        <View style={{ marginTop: 8 }}>
+          {results.map((r) => (
+            <StreamCard key={r.id} item={r} />
+          ))}
+        </View>
+
+        {guides?.streams?.length && results.length < guides.streams.length ? (
+          <Text style={styles.footerNote}>
+            Showing {results.length} of {guides.streams.length}. Adjust your profile toggles to see more.
+          </Text>
+        ) : null}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 16 },
+  center: { flex: 1, alignItems: "center", justifyContent: "center", padding: 24 },
+  header: { fontSize: 22, fontWeight: "700" },
+  meta: { marginTop: 4, color: "#666" },
+  block: { marginTop: 16, paddingTop: 8, borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: "#ddd" },
+  blockTitle: { fontSize: 16, fontWeight: "600", marginBottom: 8 },
+  toggleRow: {
+    paddingVertical: 10,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  toggleLabel: { fontSize: 15 },
+  card: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#ddd",
+    borderRadius: 12,
+    padding: 12,
+    marginBottom: 10,
+    backgroundColor: "#fff",
+  },
+  cardTitle: { fontSize: 15, fontWeight: "600" },
+  cardSub: { color: "#666", marginTop: 2 },
+  tagsRow: { flexDirection: "row", flexWrap: "wrap", marginTop: 8 },
+  tag: { paddingHorizontal: 8, paddingVertical: 4, backgroundColor: "#f1f1f1", borderRadius: 999, marginRight: 6, marginBottom: 6 },
+  tagText: { fontSize: 12, color: "#333" },
+  hint: { color: "#444", marginTop: 2 },
+  linkBtn: { marginTop: 10, paddingVertical: 10, borderRadius: 10, alignItems: "center", borderWidth: StyleSheet.hairlineWidth, borderColor: "#333" },
+  linkBtnText: { fontWeight: "600" },
+  errorTitle: { fontSize: 16, fontWeight: "700" },
+  errorSub: { marginTop: 6, color: "#666" },
+  footerNote: { color: "#666", marginTop: 8 },
+});

--- a/src/screens/ScoreScreen.tsx
+++ b/src/screens/ScoreScreen.tsx
@@ -37,6 +37,8 @@ type FswWarningsProps = {
   showPof: boolean;
 };
 
+
+
 const FswWarnings: React.FC<FswWarningsProps> = ({ showEca, showPof }) => {
   if (!showEca && !showPof) return null;
 
@@ -593,7 +595,46 @@ education,
     <DrawProximityCard freshness={prox.freshness} items={prox.items} />
   </View>
 )}
-  
+
+{/* S3-03 --- PNP Mapper quick entry (canonical) --- */}
+<View style={styles.pnpCard}>
+  <Text style={styles.pnpTitle}>Provincial Nominee Programs (PNP)</Text>
+  <Text style={styles.pnpSub}>
+    Map your profile to suggested provincial streams and open the official pages.
+  </Text>
+  <Pressable
+    onPress={() => navigation.navigate("PNPMapper" as never)}
+    style={({ pressed }) => [styles.pnpBtn, pressed && { opacity: 0.85 }]}
+    accessibilityRole="button"
+    testID="sc-open-pnp-mapper"
+  >
+    <Text style={styles.pnpBtnText}>Open PNP Mapper</Text>
+  </Pressable>
+</View>
+
+
+{/* EE Profile Checklist — maple red button (outside the Provincial options card) */}
+<View style={{ height: 10 }} />
+<Pressable
+  onPress={() => navigation.navigate("EEProfileChecklist")}
+  accessibilityRole="button"
+  testID="sc-open-ee-checklist"
+  style={{
+    alignSelf: "stretch",
+    paddingVertical: 12,
+    borderRadius: 10,           // button (not pill)
+    backgroundColor: "#B91C1C", // maple red
+    borderWidth: 1,
+    borderColor: "#991B1B",
+    justifyContent: "center",
+    alignItems: "center",
+  }}
+>
+  <Text style={{ fontSize: 15, fontWeight: "800", color: "#FFFFFF" }}>
+    EE Profile Checklist
+  </Text>
+</Pressable>
+
       </ScrollView>
 </KeyboardAvoidingView>
 
@@ -670,5 +711,24 @@ const styles = StyleSheet.create({
   justifyContent: 'center',
   alignItems: 'stretch',
 },
+  pnpCard: {
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#ddd",
+    borderRadius: 12,
+    padding: 12,
+    marginTop: 12,
+    backgroundColor: "#fff",
+  },
+  pnpTitle: { fontSize: 16, fontWeight: "600", color: colors.text },
+  pnpSub: { color: "#666", marginTop: 6 },
+  pnpBtn: {
+    marginTop: 10,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: "center",
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: "#333",
+  },
+  pnpBtnText: { fontWeight: "700", color: colors.text },
 
 });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -23,7 +23,10 @@ export const LANGUAGE_GUIDES_URL =
 export const POF_GUIDES_URL =
   'https://raw.githubusercontent.com/Omerpq/maplesteps-rules/main/data/content/guides/pof.json';
 
-export const TEMPLATE_REF_LETTER_URL =
+export const PNP_GUIDES_URL =
+  'https://raw.githubusercontent.com/Omerpq/maplesteps-rules/main/data/content/guides/pnp.json';
+
+  export const TEMPLATE_REF_LETTER_URL =
   'https://raw.githubusercontent.com/Omerpq/maplesteps-rules/main/data/templates/reference_letter.md';
 
 export const POF_THRESHOLDS_URL =

--- a/src/services/pnp.ts
+++ b/src/services/pnp.ts
@@ -1,0 +1,189 @@
+﻿// src/services/pnp.ts
+// A4-style loader for PNP guides (Rules repo) + simple profileÔåÆstream matcher.
+// Remote ÔåÆ Cache ÔåÆ Local (no Local bundle yet; remote+cache only). Uses conditional GET (ETag/Last-Modified).
+
+import { PNP_GUIDES_URL } from "./config";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+// ---------- AsyncStorage keys ----------
+const CACHE_KEY = "ms.pnp.guides.cache.v1";
+const META_KEY  = "ms.pnp.guides.meta.v1";
+
+// ---------- Types ----------
+export type PnpCategoryId =
+  | "express_entry" | "job_offer_opt" | "tech" | "health" | "trades"
+  | "french" | "intl_student" | "in_demand" | "connection";
+
+export interface PnpCategory {
+  id: PnpCategoryId;
+  title: string;
+}
+
+export interface PnpStream {
+  id: string;
+  province: string;
+  title: string;
+  categories: PnpCategoryId[];
+  hints?: string[];
+  officialUrl: string; // always link out to official sources
+}
+
+export interface PnpGuides {
+  version: string;
+  categories: PnpCategory[];
+  streams: PnpStream[];
+}
+
+// LoaderResult (local copy; matches your Updates A4 shape where practical)
+export type Source = "remote" | "cache" | "local";
+export interface LoaderMeta {
+  etag?: string;
+  last_modified?: string;
+  status?: 200 | 304;          // 200 = updated; 304 = validated (from A4)
+  last_checked?: string;       // ISO of the attempt time
+  __cachedAt?: number | null;  // ms epoch when cache was written
+}
+export interface LoaderResult<T> {
+  ok: boolean;
+  source: Source;
+  data: T | null;
+  meta?: LoaderMeta;
+  error?: string;
+}
+
+// ---------- Internal helpers ----------
+async function readCache(): Promise<LoaderResult<PnpGuides> | null> {
+  try {
+    const [dataRaw, metaRaw] = await AsyncStorage.multiGet([CACHE_KEY, META_KEY]);
+    const dataJson = dataRaw?.[1] ? JSON.parse(dataRaw[1]!) as PnpGuides : null;
+    const metaJson = metaRaw?.[1] ? JSON.parse(metaRaw[1]!) as LoaderMeta : undefined;
+    if (dataJson) {
+      return { ok: true, source: "cache", data: dataJson, meta: metaJson };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(data: PnpGuides, meta: LoaderMeta) {
+  const withTs = { ...meta, __cachedAt: Date.now() };
+  await AsyncStorage.multiSet([
+    [CACHE_KEY, JSON.stringify(data)],
+    [META_KEY, JSON.stringify(withTs)],
+  ]);
+}
+
+// ---------- Public loader ----------
+export async function loadPnpGuides(): Promise<LoaderResult<PnpGuides>> {
+  // Read existing meta for validators
+  let prevMeta: LoaderMeta | undefined;
+  try {
+    const raw = await AsyncStorage.getItem(META_KEY);
+    prevMeta = raw ? JSON.parse(raw) : undefined;
+  } catch {}
+
+  // Attempt remote with validators
+  try {
+    const headers: Record<string, string> = {};
+    if (prevMeta?.etag) headers["If-None-Match"] = prevMeta.etag;
+    if (prevMeta?.last_modified) headers["If-Modified-Since"] = prevMeta.last_modified;
+
+    const res = await fetch(PNP_GUIDES_URL, { headers });
+    const nowIso = new Date().toISOString();
+
+    if (res.status === 304) {
+      // Not modified ÔåÆ serve cache
+      const cache = await readCache();
+      if (cache?.data) {
+        const meta: LoaderMeta = {
+          ...prevMeta,
+          status: 304,
+          last_checked: nowIso,
+        };
+        return { ok: true, source: "cache", data: cache.data, meta };
+      }
+      // No cache despite 304: fall through to full fetch without validators
+    }
+
+    if (res.ok) {
+      const data = (await res.json()) as PnpGuides;
+      const meta: LoaderMeta = {
+        etag: res.headers.get("ETag") ?? undefined,
+        last_modified: res.headers.get("Last-Modified") ?? undefined,
+        status: 200,
+        last_checked: nowIso,
+      };
+      await writeCache(data, meta);
+      return { ok: true, source: "remote", data, meta };
+    }
+
+    // Remote failed ÔåÆ try cache
+    const cache = await readCache();
+    if (cache?.data) {
+      return cache;
+    }
+    return { ok: false, source: "local", data: null, error: `HTTP ${res.status}` };
+  } catch (e: any) {
+    // Network error ÔåÆ try cache
+    const cache = await readCache();
+    if (cache?.data) return cache;
+    return { ok: false, source: "local", data: null, error: e?.message || "network_error" };
+  }
+}
+
+// ---------- Profile ÔåÆ Categories mapping ----------
+export interface PnpProfileInput {
+  hasExpressEntryProfile?: boolean; // EE-aligned streams
+  hasJobOffer?: boolean;            // employer-driven / job offer
+  isTech?: boolean;                 // tech/IT occupation/experience
+  isHealth?: boolean;               // nurses, other health professions
+  isTrades?: boolean;               // skilled trades
+  isFrancophone?: boolean;          // French CLB ÔëÑ 7 typically
+  isIntlStudentOrGrad?: boolean;    // international student/graduate in Canada
+  hasProvincialTies?: boolean;      // relatives, study/work in province, invitations, etc.
+  isOccupationInDemand?: boolean;   // user says their NOC is in-demand / targeted
+}
+
+export function profileToCategoryFlags(p: PnpProfileInput): Set<PnpCategoryId> {
+  const out = new Set<PnpCategoryId>();
+  if (p.hasExpressEntryProfile) out.add("express_entry");
+  if (p.hasJobOffer) out.add("job_offer_opt");
+  if (p.isTech) out.add("tech");
+  if (p.isHealth) out.add("health");
+  if (p.isTrades) out.add("trades");
+  if (p.isFrancophone) out.add("french");
+  if (p.isIntlStudentOrGrad) out.add("intl_student");
+  if (p.hasProvincialTies) out.add("connection");
+  if (p.isOccupationInDemand) out.add("in_demand");
+  return out;
+}
+
+// Basic scorer: count of overlapping categories (ties broken by more specific streams first)
+export interface RankedStream extends PnpStream {
+  score: number;
+  matched: PnpCategoryId[];
+}
+
+export function matchStreams(guides: PnpGuides, profile: PnpProfileInput, max = 12): RankedStream[] {
+  const wants = profileToCategoryFlags(profile);
+  const entries: RankedStream[] = guides.streams.map((s) => {
+    const matched = s.categories.filter(c => wants.has(c));
+    return { ...s, score: matched.length, matched };
+  });
+
+  // Sort: score desc ÔåÆ more specific (shorter category list) ÔåÆ province alpha ÔåÆ title
+  entries.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    if (a.categories.length !== b.categories.length) return a.categories.length - b.categories.length;
+    const pa = a.province.localeCompare(b.province);
+    if (pa !== 0) return pa;
+    return a.title.localeCompare(b.title);
+  });
+
+  // If user provided nothing, just show all (alphabetical by provinceÔåÆtitle)
+  const anyFlag = wants.size > 0;
+  const list = anyFlag ? entries.filter(e => e.score > 0) : entries;
+  return list.slice(0, max);
+}
+


### PR DESCRIPTION
What’s included
- PNP Mapper: screen (PNPMapper.tsx) and service (pnp.ts)
- Config: PNP_GUIDES_URL (rules repo, A4 Remote→Cache with ETag/Last-Modified)
- Score: neutral “PNP” entry card under Draw Proximity

Validation
- First load 200 → revisit 304 (header: Remote • updated → Cache • validated)
- Toggles drive ranking (EE, job offer, tech/health/trades, Francophone, intl student, ties, in-demand)
- “Open official page” buttons go to live provincial pages/guides (PDFs OK)
